### PR TITLE
Feature/image handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # !important Gatsby theme
 
-A minimal blog theme.
+A minimal intrinsically responsive blog theme.
 
 ## Installation
 ### Install the Gatsby CLI
@@ -18,7 +18,7 @@ gatsby new gatsby-site https://github.com/gatsbyjs/gatsby-starter-hello-world
 cd gatsby-site
 ```
 
-### Install @davidway/gatsby-theme-not-important-blogá
+### Install @davidway/gatsby-theme-not-important-blog
 ```shell
 npm install @davidway/gatsby-theme-not-important-blog
 ```
@@ -29,8 +29,7 @@ or
 yarn add @davidway/gatsby-theme-not-important-blog
 ```
 
-Then add the theme to your `gatsby-config.js`. We'll use the long-form
-here for educational purposes.
+Then add the theme to your `gatsby-config.js`.
 
 ```javascript
 module.exports = {
@@ -59,8 +58,11 @@ An example file with the required frontmatter properties.
 
 ```md
 ---
+title: On Typography
 date: 2020-09-09
-title: Typography [H1]
+extract: Typography is the most important building block of your website
+featuredImage: ../images/posts/typography-reference.jpg
+featuredImageAlt: Image of type setting block
 tags:
 - Typography
 - Gatsby
@@ -88,9 +90,23 @@ This is a sentence with `inline code` in it.
 gatsby develop
 ```
 
-Note that this site doesn't _do_ anything, so you're seeing a missing
-resources error. Create a simple page in `src/pages/index.js` to see a
-page on the root url.
+Note that this theme doesn't _do_ anything until the appropriate assets have been added, 
+If you're seeing a missing resources error, create a simple page in `src/pages/index.js` to see a
+page on the root url. An example index page can be seen in the Example pages section.
+
+Add `.md` or `.mdx` files to the `src/posts` directory. These files will be transformed to pages at `/blog/[file-name]`.
+
+The following [frontmatter](https://jekyllrb.com/docs/front-matter/) values are required at the start of the post files:
+```yml
+---
+title: [Title of the post] # (*required)
+date: 2020-09-12 # (*required)
+extract: [extract describing the post]
+tags:
+- Syntax highlighting
+- Feature
+---
+```
 
 #### Example pages
 
@@ -321,4 +337,10 @@ import {
   Tag, // Displays meta information
   Card, // Summary link card
 } from "@davidway/gatsby-theme-not-important-blog";
+```
+
+## Contributing
+
+```
+npm publish --access public
 ```

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -7,6 +7,15 @@ module.exports = ({ contentPath = "src/posts", basePath = "/" }) => ({
   plugins: [
     `gatsby-plugin-react-helmet`,
     {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `images`,
+        path: `./src/images/posts`,
+      },
+    },
+    `gatsby-transformer-sharp`,
+    `gatsby-plugin-sharp`,
+    {
       resolve: `gatsby-plugin-sass`,
       options: {
         includePaths: [`node_modules`],

--- a/package.json
+++ b/package.json
@@ -4,9 +4,6 @@
   "main": "index.js",
   "author": "David Way",
   "license": "MIT",
-  "scripts": {
-    "publish": "npm publish --access public"
-  },
   "dependencies": {
     "@carbon/themes": "^10.20.0",
     "@mdx-js/loader": "^1.6.18",
@@ -18,7 +15,9 @@
     "gatsby-plugin-page-creator": "^2.3.30",
     "gatsby-plugin-react-helmet": "^3.3.13",
     "gatsby-plugin-sass": "^2.3.16",
+    "gatsby-plugin-sharp": "^2.6.40",
     "gatsby-source-filesystem": "^2.3.32",
+    "gatsby-transformer-sharp": "^2.5.17",
     "node-sass": "^4.14.1",
     "prism-react-renderer": "^1.1.1",
     "prop-types": "^15.7.2",
@@ -38,7 +37,9 @@
     "gatsby-plugin-page-creator": "^2.3.30",
     "gatsby-plugin-react-helmet": "^3.3.13",
     "gatsby-plugin-sass": "^2.3.16",
+    "gatsby-plugin-sharp": "^2.6.40",
     "gatsby-source-filesystem": "^2.3.32",
+    "gatsby-transformer-sharp": "^2.5.17",
     "node-sass": "^4.14.1",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -2,7 +2,7 @@ import React from 'react';
 import classnames from 'classnames';
 import Stack from './layout/Stack';
 
-export default function Card ({ className, to, title, meta, body}) {
+export default function Card ({ className, to, media, title, meta, body}) {
   const styleClass = classnames(
     'c-card',
     className,
@@ -12,6 +12,7 @@ export default function Card ({ className, to, title, meta, body}) {
     <article className={styleClass}>
       <a className="c-card__link" href={to}>
         <Stack spacing="small">
+          {media && media}
           <header>
             <Stack spacing="x-small">
               <h3 className="c-card__title">

--- a/src/components/layout/Reel.js
+++ b/src/components/layout/Reel.js
@@ -5,6 +5,10 @@ import useObserver from '../../hooks/ResizeObserver';
  
 function Reel({as: Element, spacing, children, className, ...otherProps}) {  
   const ref = useRef(null);
+  const containerClass = classnames(
+    'l-reel__container',
+    className,
+  );
   const styleClass = classnames(
     'l-reel',
     { [`l-reel--spacing:${spacing}`]: spacing },
@@ -16,12 +20,13 @@ function Reel({as: Element, spacing, children, className, ...otherProps}) {
   useObserver({callback: setIsOverflowing, element: ref});
 
   return (
-    <Element
-      ref={ref}
-      className={styleClass}
-      {...otherProps}
-    >
-      {children}
+    <Element className={containerClass} {...otherProps}>
+      <div
+        ref={ref}
+        className={styleClass}
+      >
+        {children}
+      </div>
     </Element>
   );
 }

--- a/src/components/layout/Sidebar.js
+++ b/src/components/layout/Sidebar.js
@@ -4,8 +4,8 @@ import classnames from 'classnames';
  
 function Sidebar({as: Element, padding, children, className, ...otherProps}) {
   const styleClass = classnames(
-    'l-box',
-    { [`l-box--padding:${padding}`]: padding },
+    'l-sidebar',
+    { [`l-sidebar--padding:${padding}`]: padding },
   );
   
   return (

--- a/src/styles/component/_card.scss
+++ b/src/styles/component/_card.scss
@@ -10,6 +10,7 @@
     &__link {
       display: flex;
       flex-direction: column;
+      height: 100%;
 
       &:hover,
       &:visited,
@@ -39,6 +40,7 @@
     &__meta {
       text-decoration: none;
       margin-top: 4px;
+      color: var(--cds-icon-02);
     }
 
     &__body {

--- a/src/styles/layout/_reel.scss
+++ b/src/styles/layout/_reel.scss
@@ -4,6 +4,8 @@
 @mixin reel {
   .l-reel {
     display: flex;
+    z-index: 1;
+    position: relative;
     overflow-x: auto;
     scrollbar-color: var(--cds-interactive-01) var(--cds-ui-background);
 
@@ -22,16 +24,49 @@
 
     > * {
       margin-right: 0;
-      min-width: 40%;
+      min-width: 60%;
+      z-index: 1;
+    }
+
+    @media (min-width: (36ch * 2)) {
+      > * {
+        min-width: 37%;
+      }
     }
 
     &::after {
       content: '';
-      flex-basis: map-get($spacing, base);
+      flex: 0 0 map-get($spacing, 'xx-small');
     }
 
     &.js-is-overflowing {
-      padding-bottom: map-get($spacing, base);
+      padding-bottom: map-get($spacing, 'small');
+    }
+
+    &__container {
+      position: relative;
+      z-index: 0;
+      overflow: hidden;
+
+      &::before,
+      &::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        z-index: 2;
+        width: 16px;
+      }
+
+      &::before {
+        left: 0;
+        background: linear-gradient(to left, rgba(255,255,255,0), rgba(255,255,255, 1));
+      }
+
+      &::after {
+        right: 0;
+        background: linear-gradient(to right, rgba(255,255,255,0), rgba(255,255,255, 1));
+      }
     }
   }
 


### PR DESCRIPTION
Added `gatsby-plugin-sharp` to the theme. This plugin in its current setting will allow access of following frontmatter properties in posts added in the `src/posts` folders.

```
featuredImage: ../images/posts/typography-reference.jpg
featuredImageAlt: Image of type setting block
```