### PR TITLE
Fix auto spaced variant of cluster causing linter warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@davidway/gatsby-theme-not-important-blog",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "main": "index.js",
   "author": "David Way",
   "license": "MIT",

--- a/src/styles/layout/_cluster.scss
+++ b/src/styles/layout/_cluster.scss
@@ -29,12 +29,14 @@
   }
 
   @each $key, $value in $spacing {
-    .l-cluster--spacing\:#{$key} {
-      margin: calc(#{$value} / 2 * -1);
-    }
+    @if $key != 'auto' {
+      .l-cluster--spacing\:#{$key} {
+        margin: calc((#{$value} / 2) * -1);   
+      }
 
-    .l-cluster--spacing\:#{$key} > * {
-      margin: calc(#{$value} / 2);
+      .l-cluster--spacing\:#{$key} > * {
+        margin: calc(#{$value} / 2);
+      }
     }
   }
 }


### PR DESCRIPTION
- due to 'auto' string used in calculation